### PR TITLE
Add optional options parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,14 @@ now you can go write useful code instead of counting how many levels you need to
 ### `require`
 create a new instance for the package based on current file directory
 ```javascript
-const pkgRequire = require('pkg-require')(__dirname);
+const pkgRequire = require('pkg-require')(__dirname, options);
 ```
+use the optional options object to provide the following additional settings
+
+| option    | type    | default | description |
+| --------- | ------- | ------- | ----------- |
+| forceRoot | boolean | false   | directly use the root path, without looking for a package.json file |
+
 
 ### `pkgRequire()`
 require a file by passing its path relative to the directory containing `package.json`

--- a/index.js
+++ b/index.js
@@ -39,7 +39,9 @@ function pkgRequireFactory(packageDir) {
   return requireInPkg;
 }
 
-function createInstance(currentDirectory) {
+function createInstance(currentDirectory, options) {
+  options = options || {};
+  
   if (
     !currentDirectory
     || typeof currentDirectory !== 'string'
@@ -52,7 +54,7 @@ function createInstance(currentDirectory) {
     );
   }
 
-  var packageDir = findPackageDir(currentDirectory);
+  var packageDir = !options.forceRoot ? findPackageDir(currentDirectory) : currentDirectory;
   return pkgRequireFactory(packageDir);
 }
 


### PR DESCRIPTION
This new optional parameter (for the core method) accepts a setting `forceRoot` of type boolean, which allows to force the provided root path, without searching for a package.json file

```javascript
const pkgRequire = require("pkg-require")(__dirname, {forceRoot: true});
```